### PR TITLE
Validate against target branch if validation is triggered by Travis PR build

### DIFF
--- a/bin/validate-commits.js
+++ b/bin/validate-commits.js
@@ -29,7 +29,10 @@ if (process.argv.indexOf('--install-git-hook') !== -1) {
     process.exit(0);
 }
 
-const commits = execSync('git log --format=%s --no-merges master..').toString();
+const command = process.env.TRAVIS_PULL_REQUEST ?
+    `git fetch --no-tags origin ${process.env.TRAVIS_BRANCH}:${process.env.TRAVIS_BRANCH} && git log --format=%s --no-merges ${process.env.TRAVIS_BRANCH}..` :
+    'git log --format=%s --no-merges master..';
+const commits = execSync(command).toString();
 const cleanCommitList = utils.filterEmptyLines(commits);
 const results = commitValidator.validate(cleanCommitList);
 reporter.printReport(results);


### PR DESCRIPTION
## What?
* If validation is triggered by a Travis PR build, validate commit messages against the target branch of the PR instead of master.

## Why?
* When you're developing against a feature branch, you want to compare your commit messages against the feature branch (target branch) rather than master.

## Testing / Proof
<img width="638" alt="screen shot 2018-04-11 at 3 29 36 pm" src="https://user-images.githubusercontent.com/667603/38597848-35735e16-3d9d-11e8-91d1-7d415afc3694.png">

@bigcommerce-labs/checkout 
