### PR TITLE
CHECKOUT-2959: Add MIT license and `bigcommerce` scope

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+(The MIT License)
+Copyright (C) 2018-Present BigCommerce Inc.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ To use it:
 or run it manually: `./node_modules/.bin/validate-commits`
 
 Enjoy!
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
-  "name": "validate-commits",
+  "name": "@bigcommerce/validate-commits",
   "version": "1.4.0",
   "description": "Validates commits based on a series of scopes/tasks",
+  "files": [
+    "bin",
+    "lib"
+  ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/bigcommerce-labs/validate-commits.git"
+    "url": "git://github.com/bigcommerce/validate-commits.git"
   },
   "author": "Bigcommerce",
-  "license": "ISC",
+  "license": "MIT",
   "bin": {
     "validate-commits": "./bin/validate-commits.js"
   },


### PR DESCRIPTION
## What?
* Add MIT license.
* Add `bigcommerce` scope.

## Why?
* In preparation for open sourcing this repo.
* Next step is to move the repo to `bigcommerce` org and release it as a npm package.

## Testing / Proof
* None

@bigcommerce/checkout  
