### PR TITLE
fix: Add missing quotes in author regex for bots

### DIFF
--- a/bin/validate-commits.js
+++ b/bin/validate-commits.js
@@ -36,7 +36,7 @@ if (execSync(`git branch --list ${baseBranch}`).toString().trim() === '') {
     process.exit(0);
 }
 
-const commits = execSync(`git log --author=\\[bot\\] --invert-grep --format=%s --no-merges ${baseBranch}..`).toString();
+const commits = execSync(`git log --author='\\[bot\\]' --invert-grep --format=%s --no-merges ${baseBranch}..`).toString();
 const cleanCommitList = utils.filterEmptyLines(commits);
 const results = commitValidator.validate(cleanCommitList);
 reporter.printReport(results);


### PR DESCRIPTION
I was missing some quotes in the author option.

@TomA-R @davidchin @PascalZajac @lord2800 