### PR TITLE
fix(common): DEVPROD-116 Make commit validation work (kinda) on CircleCI

### DIFF
--- a/bin/validate-commits.js
+++ b/bin/validate-commits.js
@@ -58,5 +58,12 @@ function getBranch() {
         return process.env.TRAVIS_BRANCH;
     }
 
+    // CircleCI does not currently provide any reference to the PR target, so the best we can assume is that we want to
+    // merge into master.
+    // Probably keep an eye on https://ideas.circleci.com/ideas/CCI-I-894 to see if they do anything about this.
+    if (process.env.CIRCLE_PR_NUMBER && process.env.CIRCLE_PR_NUMBER !== 'false') {
+        return 'origin/master';
+    }
+
     return 'master';
 }


### PR DESCRIPTION
Unlike Travis, Circle CI does not provide any environment variable or anything to allow you to know the target fork/branch of a PR. This looks like it's a reasonably requested thing, but it doesn't exist at the moment.

This means that for PRs on Circle CI, we don't really have any way to know which branch the PR is actually targeting to get the commits we should be looking at.

Given that all our projects use `master` as canonical, we can fairly safely assume that whatever's in the PR will eventually want to go to master and so comparing against that is probably okay until we can do better.

Example of it _actually_ running: https://github.com/bigcommerce/bigpay/pull/1875