### PR TITLE
refactor(common): CHP-7101 rename isValid and convert Reporter to a function

### DIFF
--- a/bin/validate-commits.js
+++ b/bin/validate-commits.js
@@ -15,14 +15,13 @@ const argv = require('minimist')(process.argv.slice(2), {
 
 const CommitValidator = require('../lib/commit-validator');
 const config = require('../lib/config');
-const Reporter = require('../lib/reporter');
+const { logReport } = require('../lib/reporter');
 const utils = require('../lib/utils');
 
 // eslint-disable-next-line no-console
 const log = argv.silent ? () => {} : console.log;
 
 const commitValidator = new CommitValidator(config);
-const reporter = new Reporter();
 
 if (argv.help) {
   log(utils.helpText);
@@ -45,7 +44,7 @@ async function run() {
   const commits = await read(getBranch());
   const { results, valid } = await commitValidator.validate(commits);
 
-  reporter.printReport(results);
+  logReport(results);
 
   if (!valid && !argv.warning) {
     process.exit(1);

--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -40,7 +40,7 @@ class CommitValidator {
     ];
   }
 
-  async isValid(commit) {
+  async validateCommit(commit) {
     return lint(commit, this.rules, {
       defaultIgnores: false,
       ignores: this.ignores,
@@ -49,7 +49,7 @@ class CommitValidator {
   }
 
   async validate(commits) {
-    const results = await Promise.all(commits.map((commit) => this.isValid(commit)));
+    const results = await Promise.all(commits.map((commit) => this.validateCommit(commit)));
 
     const valid = results.every((result) => result.valid);
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -2,25 +2,25 @@
 const format = require('@commitlint/format').default;
 const chalk = require('chalk');
 
-class Reporter {
-  printReport(results) {
-    results.forEach((result) => {
-      if (result.valid) {
-        console.log(chalk.green(result.input));
-      } else {
-        console.log(chalk.red.bold(result.input));
-      }
-    });
-
-    const output = format(
-      { results },
-      { helpUrl: 'https://github.com/bigcommerce/validate-commits/blob/master/README.md' },
-    );
-
-    if (output !== '') {
-      console.log(output);
+function logReport(results) {
+  results.forEach((result) => {
+    if (result.valid) {
+      console.log(chalk.green(result.input));
+    } else {
+      console.log(chalk.red.bold(result.input));
     }
+  });
+
+  const output = format(
+    { results },
+    { helpUrl: 'https://github.com/bigcommerce/validate-commits/blob/master/README.md' },
+  );
+
+  if (output !== '') {
+    console.log(output);
   }
 }
 
-module.exports = Reporter;
+module.exports = {
+  logReport,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,12 +62,7 @@ function installGitHook() {
   fs.writeFileSync(prePushHook, PRE_PUSH_HOOK, { mode: 0o766 });
 }
 
-function filterEmptyLines(text) {
-  return text.split('\n').filter((line) => !line.match(/^\s*$/));
-}
-
 module.exports = {
   helpText: HELP_TEXT,
   installGitHook,
-  filterEmptyLines,
 };

--- a/test/commit-validator.spec.js
+++ b/test/commit-validator.spec.js
@@ -8,72 +8,86 @@ describe('CommitValidator', () => {
   it('returns false if message does not contain valid task', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('build(foo): JIRA-1234 Add build script')).valid).toBe(false);
-    expect((await validator.isValid('doc(bar): JIRA-1234 Update docs')).valid).toBe(false);
+    expect((await validator.validateCommit('build(foo): JIRA-1234 Add build script')).valid).toBe(
+      false,
+    );
+    expect((await validator.validateCommit('doc(bar): JIRA-1234 Update docs')).valid).toBe(false);
   });
 
   it('returns false if message does not contain valid scope', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('refactor(hello): JIRA-1234 Extract method')).valid).toBe(
+    expect(
+      (await validator.validateCommit('refactor(hello): JIRA-1234 Extract method')).valid,
+    ).toBe(false);
+    expect((await validator.validateCommit('feat(world): JIRA-1234 Add new feature')).valid).toBe(
       false,
     );
-    expect((await validator.isValid('feat(world): JIRA-1234 Add new feature')).valid).toBe(false);
   });
 
   it('returns false if message does not contain ticket number', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('refactor(hello): Extract method')).valid).toBe(false);
+    expect((await validator.validateCommit('refactor(hello): Extract method')).valid).toBe(false);
   });
 
   it('returns true if message follows valid format', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('refactor(foo): JIRA-1234 Extract method')).valid).toBe(true);
-    expect((await validator.isValid('feat(bar): JIRA-1234 Add new feature')).valid).toBe(true);
+    expect((await validator.validateCommit('refactor(foo): JIRA-1234 Extract method')).valid).toBe(
+      true,
+    );
+    expect((await validator.validateCommit('feat(bar): JIRA-1234 Add new feature')).valid).toBe(
+      true,
+    );
   });
 
   it('returns false if message does not follow valid format', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('refactor[foo]: JIRA-1234 Extract method')).valid).toBe(false);
-    expect((await validator.isValid('refactor(foo): JIRA-1234: Extract method')).valid).toBe(false);
-    expect((await validator.isValid('JIRA-1234: refactor(foo) Extract method')).valid).toBe(false);
+    expect((await validator.validateCommit('refactor[foo]: JIRA-1234 Extract method')).valid).toBe(
+      false,
+    );
+    expect((await validator.validateCommit('refactor(foo): JIRA-1234: Extract method')).valid).toBe(
+      false,
+    );
+    expect((await validator.validateCommit('JIRA-1234: refactor(foo) Extract method')).valid).toBe(
+      false,
+    );
   });
 
   it('returns true if message (release commit) follows valid format', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('Releasing v1.0.0')).valid).toBe(true);
-    expect((await validator.isValid('Releasing 1.0.0')).valid).toBe(true);
-    expect((await validator.isValid('Releasing 1.0.0.rc-1')).valid).toBe(true);
-    expect((await validator.isValid('Release 1.0.0.rc-1')).valid).toBe(true);
+    expect((await validator.validateCommit('Releasing v1.0.0')).valid).toBe(true);
+    expect((await validator.validateCommit('Releasing 1.0.0')).valid).toBe(true);
+    expect((await validator.validateCommit('Releasing 1.0.0.rc-1')).valid).toBe(true);
+    expect((await validator.validateCommit('Release 1.0.0.rc-1')).valid).toBe(true);
   });
 
   it('returns false if message (release commit) does not follow valid format', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('v1.0.0')).valid).toBe(false);
-    expect((await validator.isValid('Publishing 1.0.0')).valid).toBe(false);
-    expect((await validator.isValid('Releasing v1')).valid).toBe(false);
+    expect((await validator.validateCommit('v1.0.0')).valid).toBe(false);
+    expect((await validator.validateCommit('Publishing 1.0.0')).valid).toBe(false);
+    expect((await validator.validateCommit('Releasing v1')).valid).toBe(false);
   });
 
   it('returns true if message (revert commit) follows valid format', async () => {
     const validator = new CommitValidator(options);
 
     expect(
-      (await validator.isValid('Revert "refactor(foo): JIRA-1234 Extract method"')).valid,
+      (await validator.validateCommit('Revert "refactor(foo): JIRA-1234 Extract method"')).valid,
     ).toBe(true);
-    expect((await validator.isValid('Revert "Extract method"')).valid).toBe(true);
+    expect((await validator.validateCommit('Revert "Extract method"')).valid).toBe(true);
   });
 
   it('returns false if message (revert commit) does not follow valid format', async () => {
     const validator = new CommitValidator(options);
 
-    expect((await validator.isValid('Revert refactor(foo): JIRA-1234 Extract method')).valid).toBe(
-      false,
-    );
-    expect((await validator.isValid("Revert 'Extract method'")).valid).toBe(false);
+    expect(
+      (await validator.validateCommit('Revert refactor(foo): JIRA-1234 Extract method')).valid,
+    ).toBe(false);
+    expect((await validator.validateCommit("Revert 'Extract method'")).valid).toBe(false);
   });
 });


### PR DESCRIPTION
## What/Why

- Renames `isValid` to `validateCommit` to be more synonymous with it's functionality.
- Converts `Reporter` class to a simple function.
- Removes unused function `filterEmptyLines`