### PR TITLE
refactor(tests): CHP-7101 update tests to test for validation messages

### DIFF
--- a/commit-validation.json
+++ b/commit-validation.json
@@ -1,6 +1,7 @@
 {
     "scopes": [
         "common",
-        "deps"
+        "deps",
+        "tests"
     ]
 }


### PR DESCRIPTION
## What/Why?

Refactors tests to test for validation errors, rather than if the commit is valid or not.

_Note:_ I'm not 100% sold on the way I split the tests out. Let me know if there is something better.

## Screenshot
<img width="591" alt="Screen Shot 2021-08-31 at 16 39 22" src="https://user-images.githubusercontent.com/10539418/131579334-63ce5ed9-f8e1-4882-9420-ae25bec14e94.png">
