### PR TITLE
Allow numbers in JIRA project ID

### DIFF
--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -31,7 +31,7 @@ class CommitValidator {
             return [
               // We return true so we don't report on an empty subject
               // The subject-empty rule will take care of that.
-              subject ? subject.match(/^[A-Z]{2,}-\d+ /) : true,
+              subject ? subject.match(/^[A-Z0-9]{2,}-\d+ /) : true,
               `Your subject must contain a JIRA ticket (i.e. BIG-123).`,
             ];
           },


### PR DESCRIPTION
Some projects include numbers in their keys, e.g: `BIG4-123`.
With this change, numbers and letters are accepted as a project ID.