### PR TITLE
fix(common): CMX-2132 Allow bots bumping deps without jira tickets

### DIFF
--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -27,11 +27,21 @@ class CommitValidator {
     this.plugins = [
       {
         rules: {
-          'subject-start-jira': ({ subject }) => {
+          'subject-start-jira': ({ subject, raw }) => {
+            // Want to allow bots to not have jira tickets
+            // Author information is not available within the plugin function arguments, patching for now.
+            // https://github.com/conventional-changelog/commitlint/issues/2455
+            const deps = 'chore(deps): Bump';
+            const depsDev = 'chore(deps-dev): Bump';
+            const isValid = () =>
+              raw.startsWith(deps) ||
+              raw.startsWith(depsDev) ||
+              subject.match(/^[A-Z0-9]{2,}-\d+ /);
+
             return [
               // We return true so we don't report on an empty subject
               // The subject-empty rule will take care of that.
-              subject ? subject.match(/^[A-Z0-9]{2,}-\d+ /) : true,
+              subject ? isValid() : true,
               `Your subject must contain a JIRA ticket (i.e. BIG-123).`,
             ];
           },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
## What
In our recent adoption of `commitlint` package we have not accounted for bot PRs not having JIRA tickets. As far as I can see, dependabot PRs will fail with our latest version 2.3.0

Example: https://app.circleci.com/pipelines/github/bigcommerce/listing-management-ui/647/workflows/e28cdb83-b829-4cf2-b93d-58362c26936e/jobs/2950

It looks like, unfortunately, their plugin arguments do not contain author information (ideally we'd use author info to allow bots to not have JIRA tickets): https://github.com/conventional-changelog/commitlint/issues/2455, 

I'm not fully sold on the code on this PR but wanted to open it up to start some discussions around it