### PR TITLE
Remove validating against proper sentences in commit messages

### DIFF
--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -13,7 +13,6 @@ class CommitValidator {
       'scope-enum': [2, 'always', options.scopes],
       'scope-empty': [2, 'never'],
       'subject-empty': [2, 'never'],
-      'subject-full-stop': [2, 'never', '.'],
       'subject-start-jira': [2, 'always'],
       'type-case': [2, 'always', 'lower-case'],
       'type-enum': [

--- a/test/commit-validator.spec.js
+++ b/test/commit-validator.spec.js
@@ -31,6 +31,16 @@ describe('commit returns true if', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('ends with a full stop', async () => {
+    const { valid, errors, warnings } = await validator.validateCommit(
+      'refactor(foo): JIRA-1234 Extract method.',
+    );
+
+    expect(valid).toBe(true);
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
   describe('release', () => {
     it('contains a prefix', async () => {
       const { valid, errors, warnings } = await validator.validateCommit('Releasing v1.0.0');


### PR DESCRIPTION
#### What
Remove the validation that stops us from being able to use full stops in our commit message.
So that the following commit message does not fail pre-checks: 
`fix(someScope): SOMETICKET-1111 I made this change for a good reason.`

#### Why
Because this is incredibly frustrating. Having to amend commit messages because I wrote a proper sentence.

If there is a valid reason for this I am happy to close this, but at present it is causing pain.

#### Proofs
Not sure how to test this since the way this surfaces is from creating a PR in bcapp.