### PR TITLE
Add new allow format for commit message

### DIFF
--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -23,7 +23,21 @@ class CommitValidator {
       'type-enum': [
         2,
         'always',
-        ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'license', 'meta', 'perf', 'ref', 'revert', 'style', 'test'],
+        [
+          'build',
+          'chore',
+          'ci',
+          'docs',
+          'feat',
+          'fix',
+          'license',
+          'meta',
+          'perf',
+          'ref',
+          'revert',
+          'style',
+          'test',
+        ],
       ],
       'type-empty': [2, 'never'],
     };
@@ -87,16 +101,25 @@ class CommitValidator {
       }),
     ]);
 
-    const passingResult = newResult.valid ? newResult : legacyResult.valid ? legacyResult : null;
+    let passingResult = null;
+
+    if (newResult.valid) {
+      passingResult = newResult;
+    } else if (legacyResult.valid) {
+      passingResult = legacyResult;
+    }
+
     if (passingResult) {
       const warnings = [...newResult.warnings, ...legacyResult.warnings].filter(
         (w, i, arr) => arr.findIndex((x) => x.name === w.name) === i,
       );
+
       return { ...passingResult, warnings };
     }
 
     // Both failed — return errors from whichever format the commit appears to target
     const looksLikeNewFormat = /^[A-Z0-9]{2,}-\d+:/.test(commit);
+
     return looksLikeNewFormat ? newResult : legacyResult;
   }
 

--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -7,7 +7,42 @@ class CommitValidator {
       (commit) => new RegExp('^Revert ".+').test(commit),
     ];
 
-    this.rules = {
+    // New format: JIRA-123: type(scope) - subject
+    this.newParserOpts = {
+      headerPattern: /^[A-Z0-9]{2,}-\d+: (\w*)(?:\(([^)]*)\))?(?:!)? - (.*)$/,
+      headerCorrespondence: ['type', 'scope', 'subject'],
+    };
+
+    this.newRules = {
+      'body-leading-blank': [1, 'always'],
+      'footer-leading-blank': [1, 'always'],
+      'scope-enum': [2, 'always', options.scopes],
+      'subject-empty': [2, 'never'],
+      'header-match-bc-format': [2, 'always'],
+      'type-case': [2, 'always', 'lower-case'],
+      'type-enum': [
+        2,
+        'always',
+        ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'license', 'meta', 'perf', 'ref', 'revert', 'style', 'test'],
+      ],
+      'type-empty': [2, 'never'],
+    };
+
+    this.newPlugins = [
+      {
+        rules: {
+          'header-match-bc-format': ({ header }) => {
+            return [
+              header ? /^[A-Z0-9]{2,}-\d+: \w+(\([^)]*\))?!? - .+/.test(header) : true,
+              'Header must follow format: JIRA-123: type(scope) - subject',
+            ];
+          },
+        },
+      },
+    ];
+
+    // Legacy format: type(scope): JIRA-123 subject
+    this.legacyRules = {
       'body-leading-blank': [1, 'always'],
       'footer-leading-blank': [1, 'always'],
       'scope-enum': [2, 'always', options.scopes],
@@ -23,13 +58,11 @@ class CommitValidator {
       'type-empty': [2, 'never'],
     };
 
-    this.plugins = [
+    this.legacyPlugins = [
       {
         rules: {
           'subject-start-jira': ({ subject }) => {
             return [
-              // We return true so we don't report on an empty subject
-              // The subject-empty rule will take care of that.
               subject ? subject.match(/^[A-Z0-9]{2,}-\d+ /) : true,
               `Your subject must contain a JIRA ticket (i.e. BIG-123).`,
             ];
@@ -40,11 +73,29 @@ class CommitValidator {
   }
 
   async validateCommit(commit) {
-    return lint(commit, this.rules, {
-      defaultIgnores: false,
-      ignores: this.ignores,
-      plugins: this.plugins,
-    });
+    const [newResult, legacyResult] = await Promise.all([
+      lint(commit, this.newRules, {
+        defaultIgnores: false,
+        ignores: this.ignores,
+        parserOpts: this.newParserOpts,
+        plugins: this.newPlugins,
+      }),
+      lint(commit, this.legacyRules, {
+        defaultIgnores: false,
+        ignores: this.ignores,
+        plugins: this.legacyPlugins,
+      }),
+    ]);
+
+    if (newResult.valid || legacyResult.valid) {
+      return { valid: true, errors: [], warnings: [...newResult.warnings, ...legacyResult.warnings].filter(
+        (w, i, arr) => arr.findIndex((x) => x.name === w.name) === i,
+      )};
+    }
+
+    // Both failed — return errors from whichever format the commit appears to target
+    const looksLikeNewFormat = /^[A-Z0-9]{2,}-\d+:/.test(commit);
+    return looksLikeNewFormat ? newResult : legacyResult;
   }
 
   async validate(commits) {

--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -87,10 +87,12 @@ class CommitValidator {
       }),
     ]);
 
-    if (newResult.valid || legacyResult.valid) {
-      return { valid: true, errors: [], warnings: [...newResult.warnings, ...legacyResult.warnings].filter(
+    const passingResult = newResult.valid ? newResult : legacyResult.valid ? legacyResult : null;
+    if (passingResult) {
+      const warnings = [...newResult.warnings, ...legacyResult.warnings].filter(
         (w, i, arr) => arr.findIndex((x) => x.name === w.name) === i,
-      )};
+      );
+      return { ...passingResult, warnings };
     }
 
     // Both failed — return errors from whichever format the commit appears to target

--- a/test/commit-validator.spec.js
+++ b/test/commit-validator.spec.js
@@ -11,29 +11,93 @@ beforeEach(() => {
 });
 
 describe('commit returns true if', () => {
-  it('follows valid format', async () => {
-    const { valid, errors, warnings } = await validator.validateCommit(
-      'refactor(foo): JIRA-1234 Extract method',
-    );
+  describe('new format (JIRA-123: type(scope) - subject)', () => {
+    it('follows valid format', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        'JIRA-1234: ref(foo) - Extract method',
+      );
 
-    expect(valid).toBe(true);
-    expect(errors).toEqual([]);
-    expect(warnings).toEqual([]);
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('follows valid format without scope', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        'JIRA-1234: ref - Extract method',
+      );
+
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('ends with a full stop', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        'JIRA-1234: ref(foo) - Extract method.',
+      );
+
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('follows valid breaking change format', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        `
+        JIRA-1234: feat(bar) - Use new method
+
+        BREAKING CHANGE:
+        Use new method instead of old one.
+      `.trim(),
+      );
+
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+  });
+
+  describe('legacy format (type(scope): JIRA-123 subject)', () => {
+    it('follows valid format', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        'refactor(foo): JIRA-1234 Extract method',
+      );
+
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('ends with a full stop', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        'refactor(foo): JIRA-1234 Extract method.',
+      );
+
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
+
+    it('follows valid breaking change format', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        `
+        feat(bar): JIRA-1234 use new method
+
+        BREAKING CHANGE:
+        Use new method instead of old one.
+      `.trim(),
+      );
+
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
   });
 
   it('follows valid revert format', async () => {
     const { valid, errors, warnings } = await validator.validateCommit(
-      'Revert "refactor(foo): JIRA-1234 Extract method"',
-    );
-
-    expect(valid).toBe(true);
-    expect(errors).toEqual([]);
-    expect(warnings).toEqual([]);
-  });
-
-  it('ends with a full stop', async () => {
-    const { valid, errors, warnings } = await validator.validateCommit(
-      'refactor(foo): JIRA-1234 Extract method.',
+      'Revert "JIRA-1234: ref(foo) - Extract method"',
     );
 
     expect(valid).toBe(true);
@@ -75,12 +139,11 @@ describe('commit returns true if', () => {
     });
   });
 
-  describe('breaking change', () => {
-    it('follows valid format', async () => {
+  describe('breaking change warning if no leading blank line', () => {
+    it('new format', async () => {
       const { valid, errors, warnings } = await validator.validateCommit(
         `
-        feat(bar): JIRA-1234 use new method
-
+        JIRA-1234: feat(bar) - Use new method
         BREAKING CHANGE:
         Use new method instead of old one.
       `.trim(),
@@ -88,10 +151,11 @@ describe('commit returns true if', () => {
 
       expect(valid).toBe(true);
       expect(errors).toEqual([]);
-      expect(warnings).toEqual([]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings).toStrictEqual([expect.objectContaining({ name: 'footer-leading-blank' })]);
     });
 
-    it('contains warning if no leading blank line', async () => {
+    it('legacy format', async () => {
       const { valid, errors, warnings } = await validator.validateCommit(
         `
         feat(bar): JIRA-1234 use new method
@@ -109,7 +173,18 @@ describe('commit returns true if', () => {
 });
 
 describe('commit returns false if', () => {
-  it('contains invalid task', async () => {
+  it('contains invalid type (new format)', async () => {
+    const { valid, errors, warnings } = await validator.validateCommit(
+      'JIRA-1234: unknown(foo) - Add something',
+    );
+
+    expect(valid).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(warnings).toEqual([]);
+    expect(errors).toStrictEqual([expect.objectContaining({ name: 'type-enum' })]);
+  });
+
+  it('contains invalid type (legacy format)', async () => {
     const { valid, errors, warnings } = await validator.validateCommit(
       'build(foo): JIRA-1234 Add build script',
     );
@@ -120,7 +195,18 @@ describe('commit returns false if', () => {
     expect(errors).toStrictEqual([expect.objectContaining({ name: 'type-enum' })]);
   });
 
-  it('contains invalid scope', async () => {
+  it('contains invalid scope (new format)', async () => {
+    const { valid, errors, warnings } = await validator.validateCommit(
+      'JIRA-1234: ref(hello) - Extract method',
+    );
+
+    expect(valid).toBe(false);
+    expect(errors).toHaveLength(1);
+    expect(warnings).toEqual([]);
+    expect(errors).toStrictEqual([expect.objectContaining({ name: 'scope-enum' })]);
+  });
+
+  it('contains invalid scope (legacy format)', async () => {
     const { valid, errors, warnings } = await validator.validateCommit(
       'refactor(hello): JIRA-1234 Extract method',
     );
@@ -131,7 +217,7 @@ describe('commit returns false if', () => {
     expect(errors).toStrictEqual([expect.objectContaining({ name: 'scope-enum' })]);
   });
 
-  it('does not contain ticket number', async () => {
+  it('does not contain ticket number (legacy format)', async () => {
     const { valid, errors, warnings } = await validator.validateCommit(
       'refactor(foo): Extract method',
     );
@@ -142,9 +228,9 @@ describe('commit returns false if', () => {
     expect(errors).toStrictEqual([expect.objectContaining({ name: 'subject-start-jira' })]);
   });
 
-  it('contains invalid scope format', async () => {
+  it('does not contain ticket number', async () => {
     const { valid, errors, warnings } = await validator.validateCommit(
-      'refactor[foo]: JIRA-1234 Extract method',
+      'ref(foo) - Extract method',
     );
 
     expect(valid).toBe(false);
@@ -157,28 +243,17 @@ describe('commit returns false if', () => {
     ]);
   });
 
-  it('contains invalid JIRA ticket', async () => {
+  it('contains invalid scope format', async () => {
     const { valid, errors, warnings } = await validator.validateCommit(
-      'refactor(foo): JIRA-1234: Extract method',
-    );
-
-    expect(valid).toBe(false);
-    expect(errors).toHaveLength(1);
-    expect(warnings).toEqual([]);
-    expect(errors).toStrictEqual([expect.objectContaining({ name: 'subject-start-jira' })]);
-  });
-
-  it('JIRA tickets is first', async () => {
-    const { valid, errors, warnings } = await validator.validateCommit(
-      'JIRA-1234: refactor(foo) Extract method',
+      'JIRA-1234: ref[foo] - Extract method',
     );
 
     expect(valid).toBe(false);
     expect(errors).toHaveLength(3);
     expect(warnings).toEqual([]);
     expect(errors).toStrictEqual([
-      expect.objectContaining({ name: 'scope-empty' }),
       expect.objectContaining({ name: 'subject-empty' }),
+      expect.objectContaining({ name: 'header-match-bc-format' }),
       expect.objectContaining({ name: 'type-empty' }),
     ]);
   });
@@ -240,7 +315,7 @@ describe('commit returns false if', () => {
   describe('revert', () => {
     it('does not contain quotes', async () => {
       const { valid, errors, warnings } = await validator.validateCommit(
-        'Revert refactor(foo): JIRA-1234 Extract method',
+        'Revert JIRA-1234: ref(foo) - Extract method',
       );
 
       expect(valid).toBe(false);

--- a/test/commit-validator.spec.js
+++ b/test/commit-validator.spec.js
@@ -229,9 +229,7 @@ describe('commit returns false if', () => {
   });
 
   it('does not contain ticket number', async () => {
-    const { valid, errors, warnings } = await validator.validateCommit(
-      'ref(foo) - Extract method',
-    );
+    const { valid, errors, warnings } = await validator.validateCommit('ref(foo) - Extract method');
 
     expect(valid).toBe(false);
     expect(errors).toHaveLength(3);


### PR DESCRIPTION
The current format is like `feat(platform): JIRA-123 description` where the new claude bc skill use a slightly different format of `JIRA-123: feat(platform) description` see (https://github.com/bigcommerce/cc-plugins-marketplace/blob/main/plugins/bc-skills/skills/commit/SKILL.md) 

So this PR is to add support for the new format so claude created PR won't fail commit message validation while still supports the old one for backward compatibility.