### PR TITLE
chore(common): PHPMNT-378 Add "refactor" to list of allowed types

### DIFF
--- a/lib/commit-validator.js
+++ b/lib/commit-validator.js
@@ -34,6 +34,7 @@ class CommitValidator {
           'meta',
           'perf',
           'ref',
+          'refactor',
           'revert',
           'style',
           'test',

--- a/test/commit-validator.spec.js
+++ b/test/commit-validator.spec.js
@@ -56,6 +56,18 @@ describe('commit returns true if', () => {
       expect(errors).toEqual([]);
       expect(warnings).toEqual([]);
     });
+
+    it('supports the type "refactor"', async () => {
+      const { valid, errors, warnings } = await validator.validateCommit(
+        `
+        JIRA-1234: refactor(bar) - Refactor all the things
+      `.trim(),
+      );
+
+      expect(valid).toBe(true);
+      expect(errors).toEqual([]);
+      expect(warnings).toEqual([]);
+    });
   });
 
   describe('legacy format (type(scope): JIRA-123 subject)', () => {


### PR DESCRIPTION
Jira: [PHPMNT-378](https://bigcommercecloud.atlassian.net/browse/PHPMNT-378)

## What/Why?
Add "refactor" to list of allowed types. It's documented to be a valid type, so should be. I also much prefer it over "ref"

## Rollout/Rollback
Merge / revert

## Testing
`npm run test` passes on this PR

[PHPMNT-378]: https://bigcommercecloud.atlassian.net/browse/PHPMNT-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ